### PR TITLE
Fixes #3: Format String With Named Arguments

### DIFF
--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -107,10 +107,11 @@ class ActivityWatcher(object):
             return
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Activity %(path)s emitted BuddyJoined("%(buddy)s") 
-				or mentioned the buddy in GetJoinedBuddies') %
-                            {'path': self.object_path, 'buddy': buddy})
+        self.ps_watcher.log(
+            _('INFO') + ': '
+			+ _('Activity %(path)s emitted BuddyJoined("%(buddy)s") 
+            or mentioned the buddy in GetJoinedBuddies') %
+            {'path': self.object_path, 'buddy': buddy})
         self.buddies.append(buddy)
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
                                                   ' '.join(self.buddies))
@@ -120,9 +121,9 @@ class ActivityWatcher(object):
             return
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
-                            {'path': self.object_path, 'buddy': buddy})
+        self.ps_watcher.log(
+			_('INFO') + ': ' + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
+            {'path': self.object_path, 'buddy': buddy})
         try:
             self.buddies.remove(buddy)
         except ValueError:
@@ -136,9 +137,9 @@ class ActivityWatcher(object):
             self._on_buddy_joined(buddy)
 
     def _on_get_buddies_failure(self, e):
-        self.log(_('ERROR') + ': ' 
-		 + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') % 
-                 {'path': self.object_path, 'e': e})
+        self.log(
+            _('ERROR') + ': ' + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
                                                   '!')
 
@@ -147,10 +148,11 @@ class ActivityWatcher(object):
             return
         if channel.startswith(self.full_conn):
             channel = '...' + channel[len(self.full_conn):]
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Activity %(path)s emitted NewChannel("%(channel)s")
-				or mentioned the channel in GetChannels()') %
-                            {'path': self.object_path, 'channel': channel})
+        self.ps_watcher.log(
+            _('INFO') + ': '
+			+ _('Activity %(path)s emitted NewChannel("%(channel)s")
+            or mentioned the channel in GetChannels()') %
+            {'path': self.object_path, 'channel': channel})
         self.channels.append(channel)
         # FIXME: listen for Telepathy Closed signal!
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CHANNELS,
@@ -171,9 +173,10 @@ class ActivityWatcher(object):
                                                   ' '.join(self.channels))
 
     def _on_get_channels_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Activity %(path)s>.GetChannels(): %(e)s') %
-                            {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': '
+			+ _('<Activity %(path)s>.GetChannels(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CONN,
                                                   '!')
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CHANNELS,
@@ -184,9 +187,10 @@ class ActivityWatcher(object):
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_ID, ident)
 
     def _on_get_id_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Activity %(path)s>.GetId(): %(e)s') %
-                            {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': '
+            + _('<Activity %(path)s>.GetId(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_ID,
                                                   '!')
 
@@ -196,9 +200,10 @@ class ActivityWatcher(object):
                                                   color)
 
     def _on_get_color_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Activity %(path)s>.GetColor(): %(e)s') %
-                            {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': '
+            + _('<Activity %(path)s>.GetColor(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_COLOR,
                                                   '!')
 
@@ -208,9 +213,10 @@ class ActivityWatcher(object):
                                                   type_)
 
     def _on_get_type_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Activity %(path)s>.GetType(): %(e)s') %
-                            {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': ' 
+            + _('<Activity %(path)s>.GetType(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_TYPE,
                                                   '!')
 
@@ -220,9 +226,10 @@ class ActivityWatcher(object):
                                                   name)
 
     def _on_get_name_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Activity %(path)s>.GetName(): %(e)s') %
-                            {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': ' 
+            + _('<Activity %(path)s>.GetName(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_NAME,
                                                   '!')
 
@@ -248,8 +255,8 @@ class BuddyWatcher(object):
     def __init__(self, ps_watcher, object_path):
         self.ps_watcher = ps_watcher
         self.bus = ps_watcher.bus
-        self.proxy = self.bus.get_object(self.ps_watcher.unique_name,
-                                         object_path)
+        self.proxy = self.bus.get_object(
+            self.ps_watcher.unique_name, object_path)
         self.iface = dbus.Interface(self.proxy, BUDDY_IFACE)
         self.object_path = object_path
         self.appearing = True
@@ -282,9 +289,9 @@ class BuddyWatcher(object):
                                        error_handler=self._on_get_acts_failure)
 
         self.iface.connect_to_signal('TelepathyHandleAdded',
-                                    self._on_handle_added)
+                                     self._on_handle_added)
         self.iface.connect_to_signal('TelepathyHandleRemoved',
-                                    self._on_handle_removed)
+                                     self._on_handle_removed)
         self.ps_watcher.log(_('Calling <Buddy %s>.GetTelepathyHandles()'),
                             object_path)
         self.iface.GetTelepathyHandles(
@@ -294,14 +301,15 @@ class BuddyWatcher(object):
     def _on_handle_added(self, service, conn, handle):
         if self.handles is None:
             return
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
-                            '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
-                            'GetTelepathyHandles()').format
-                            % {'object_path': self.object_path,
-			       'service': service,
-			       'conn': conn,
-			       'handle': handle }
+        self.ps_watcher.log(
+            _('INFO') + ': '
+            + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
+            '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
+            'GetTelepathyHandles()').format
+            % {'object_path': self.object_path,
+               'service': service,
+               'conn': conn,
+               'handle': handle }
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
         self.handles.append('%u@%s' % (handle, conn))
@@ -314,9 +322,10 @@ class BuddyWatcher(object):
             return
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') % 
-			    {'path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
+        self.ps_watcher.log(
+            _('INFO') + ': '
+			+ _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') %
+			{'path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
         try:
             self.handles.remove('%u@%s' % (handle, conn))
         except ValueError:
@@ -330,8 +339,10 @@ class BuddyWatcher(object):
             self._on_handle_added(service, conn, handle)
 
     def _on_get_handles_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' +_('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
-                 {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(
+            _('ERROR') + ': '
+            +_('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
+            {'path':self.object_path, 'e':e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_HANDLES,
                                                '!')
 
@@ -379,9 +390,10 @@ class BuddyWatcher(object):
     def _on_props_changed(self, props):
         try:
             logger.debug('PropertyChanged(%s, %s)', self, props)
-            self.ps_watcher.log(_('INFO') + ': ' 
+            self.ps_watcher.log(
+                _('INFO') + ': '
 				+ _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
-                                {'path': self.object_path, 'props': props})
+                {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
             self.ps_watcher.log(_('INTERNAL ERROR: %s'), e)
@@ -389,9 +401,10 @@ class BuddyWatcher(object):
     def _on_get_props_success(self, props):
         try:
             logger.debug('GetProperties(%s, %s)', self, props)
-            self.ps_watcher.log(_('INFO') + ': ' 
+            self.ps_watcher.log(
+                _('INFO') + ': '
 				+ _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
-                     {'path': self.object_path, 'props': props})
+                {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
             self.ps_watcher.log(_('INTERNAL ERROR: %s'), e)
@@ -637,7 +650,8 @@ class PresenceServiceWatcher(VBox):
         self.log(_('INFO') + ': ' + _('PS emitted ActivityDisappeared("%s")'), path)
         act = self.activities.get(path)
         if act is None:
-            self.log(_('WARNING') + ': ' + _('Trying to remove activity "%s" which is already absent'), path)
+            self.log(_('WARNING') + ': '
+                     + _('Trying to remove activity "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             act.disappear()
@@ -646,7 +660,8 @@ class PresenceServiceWatcher(VBox):
         self.log(_('INFO') + ': ' + _('PS emitted ActivityInvitation("%s")'), path)
 
     def _on_private_invitation(self, bus_name, conn, channel):
-        self.log(_('INFO') + ': ' + _('PS emitted PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
+        self.log(_('INFO') + ': ' 
+                 + _('PS emitted PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
                  {'bus':bus_name, 'conn':conn, 'channel':channel})
 
     def _on_get_buddies_success(self, paths):
@@ -701,8 +716,8 @@ class PresenceServiceNameWatcher(VBox):
         self.errors = ListStore(str)
 
         errors_tree = TreeView(model=self.errors)
-        errors_tree.insert_column_with_attributes(0, _('Log'), CellRendererText(),
-                                             text=0)
+        errors_tree.insert_column_with_attributes(
+            0, _('Log'), CellRendererText(), text=0)
         scroller = ScrolledWindow()
         scroller.add(errors_tree)
 
@@ -724,8 +739,8 @@ class PresenceServiceNameWatcher(VBox):
     def on_name_owner_change(self, owner):
         try:
             if owner:
-                self.label.set_text(_('Presence Service running: unique name %s')
-                                    % owner)
+                self.label.set_text(
+                    _('Presence Service running: unique name %s') % owner)
                 if self.ps_watcher is not None:
                     self.paned.remove(self.ps_watcher)
                 self.ps_watcher = PresenceServiceWatcher(self.bus, owner,

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -109,8 +109,7 @@ class ActivityWatcher(object):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
             _('INFO') + ': '
-			+ _('Activity %(path)s emitted BuddyJoined("%(buddy)s") 
-            or mentioned the buddy in GetJoinedBuddies') %
+            + _('Activity %(path)s emitted BuddyJoined("%(buddy)s") or mentioned the buddy in GetJoinedBuddies') %
             {'path': self.object_path, 'buddy': buddy})
         self.buddies.append(buddy)
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
@@ -122,7 +121,7 @@ class ActivityWatcher(object):
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
-			_('INFO') + ': ' + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
+            _('INFO') + ': ' + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
             {'path': self.object_path, 'buddy': buddy})
         try:
             self.buddies.remove(buddy)
@@ -138,7 +137,8 @@ class ActivityWatcher(object):
 
     def _on_get_buddies_failure(self, e):
         self.log(
-            _('ERROR') + ': ' + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') %
+            _('ERROR') + ': '
+            + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
                                                   '!')
@@ -150,8 +150,7 @@ class ActivityWatcher(object):
             channel = '...' + channel[len(self.full_conn):]
         self.ps_watcher.log(
             _('INFO') + ': '
-			+ _('Activity %(path)s emitted NewChannel("%(channel)s")
-            or mentioned the channel in GetChannels()') %
+            + _('Activity %(path)s emitted NewChannel("%(channel)s") or mentioned the channel in GetChannels()') %
             {'path': self.object_path, 'channel': channel})
         self.channels.append(channel)
         # FIXME: listen for Telepathy Closed signal!
@@ -175,7 +174,7 @@ class ActivityWatcher(object):
     def _on_get_channels_failure(self, e):
         self.ps_watcher.log(
             _('ERROR') + ': '
-			+ _('<Activity %(path)s>.GetChannels(): %(e)s') %
+            + _('<Activity %(path)s>.GetChannels(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CONN,
                                                   '!')
@@ -214,7 +213,7 @@ class ActivityWatcher(object):
 
     def _on_get_type_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': ' 
+            _('ERROR') + ': '
             + _('<Activity %(path)s>.GetType(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_TYPE,
@@ -227,7 +226,7 @@ class ActivityWatcher(object):
 
     def _on_get_name_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': ' 
+            _('ERROR') + ': '
             + _('<Activity %(path)s>.GetName(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_NAME,
@@ -276,7 +275,8 @@ class BuddyWatcher(object):
 
         self.iface.connect_to_signal('PropertyChanged', self._on_props_changed,
                                      byte_arrays=True)
-        self.ps_watcher.log(_('Calling <Buddy %s>.GetProperties()'), object_path)
+        self.ps_watcher.log(
+            _('Calling <Buddy %s>.GetProperties()'), object_path)
         self.iface.GetProperties(reply_handler=self._on_get_props_success,
                                  error_handler=self._on_get_props_failure,
                                  byte_arrays=True)
@@ -324,8 +324,8 @@ class BuddyWatcher(object):
             conn = '.../' + conn[38:]
         self.ps_watcher.log(
             _('INFO') + ': '
-			+ _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') %
-			{'path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
+            + _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') %
+            {'path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
         try:
             self.handles.remove('%u@%s' % (handle, conn))
         except ValueError:
@@ -351,10 +351,10 @@ class BuddyWatcher(object):
             return
         if act.startswith('/org/laptop/Sugar/Presence/Activities/'):
             act = '.../' + act[38:]
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Buddy %(path)s emitted ActivityJoined("%(act)s") 
-				or mentioned it in GetJoinedActivities()') %
-                            {'path': self.object_path, 'act': act})
+        self.ps_watcher.log(
+            _('INFO') + ': '
+            + _('Buddy %(path)s emitted ActivityJoined("%(act)s") or mentioned it in GetJoinedActivities()') %
+            {'path': self.object_path, 'act': act})
         self.activities.append(act)
         self.ps_watcher.buddies_list_store.set(self.iter,
                                                BUDDY_COL_ACTIVITIES,
@@ -365,9 +365,10 @@ class BuddyWatcher(object):
             return
         if act.startswith('/org/laptop/Sugar/Presence/Activities/'):
             act = '.../' + act[38:]
-        self.ps_watcher.log(_('INFO') + ': ' 
-			    + _('Buddy %(path)s emitted ActivityLeft("%(act)s")') %
-                            {'path': self.object_path, 'act': act})
+        self.ps_watcher.log(
+            _('INFO') + ': '
+            + _('Buddy %(path)s emitted ActivityLeft("%(act)s")') %
+            {'path': self.object_path, 'act': act})
         try:
             self.activities.remove(act)
         except ValueError:
@@ -381,9 +382,10 @@ class BuddyWatcher(object):
             self._on_joined(act)
 
     def _on_get_acts_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Buddy %(path)s>.GetJoinedActivities(): %(e)s') %
-                 {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': '
+            + _('<Buddy %(path)s>.GetJoinedActivities(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_ACTIVITIES,
                                                '!')
 
@@ -392,8 +394,8 @@ class BuddyWatcher(object):
             logger.debug('PropertyChanged(%s, %s)', self, props)
             self.ps_watcher.log(
                 _('INFO') + ': '
-				+ _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
-                {'path': self.object_path, 'props': props})
+                + _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
+               {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
             self.ps_watcher.log(_('INTERNAL ERROR: %s'), e)
@@ -403,7 +405,7 @@ class BuddyWatcher(object):
             logger.debug('GetProperties(%s, %s)', self, props)
             self.ps_watcher.log(
                 _('INFO') + ': '
-				+ _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
+                + _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
                 {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
@@ -425,12 +427,12 @@ class BuddyWatcher(object):
                                                    self.color)
         if 'ip4-address' in props:
             self.ipv4 = props.get('ip4-address', '?')
-            self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_IP4,
-                                                   self.ipv4)
+            self.ps_watcher.buddies_list_store.set(
+                self.iter, BUDDY_COL_IP4, self.ipv4)
         if 'current-activity' in props:
             self.cur_act = props.get('current-activity', '?')
-            self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_CUR_ACT,
-                                                   self.cur_act)
+            self.ps_watcher.buddies_list_store.set(
+                self.iter, BUDDY_COL_CUR_ACT, self.cur_act)
         if 'key' in props:
             key = props.get('key', None)
             if key:
@@ -444,9 +446,10 @@ class BuddyWatcher(object):
         logger.debug('End _props_changed')
 
     def _on_get_props_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' 
-			    + _('<Buddy %(path)s>.GetProperties(): %(e)s') %
-                            {'path': self.object_path, 'e': e})
+        self.ps_watcher.log(
+            _('ERROR') + ': '
+            + _('<Buddy %(path)s>.GetProperties(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_NICK, '!')
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_OWNER,
                                                False)
@@ -542,12 +545,14 @@ class PresenceServiceWatcher(VBox):
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_NAME)
-        c = self.activities_list.insert_column_with_attributes(5, _('Connection'),
+        c = self.activities_list.insert_column_with_attributes(
+            5, _('Connection'),
             CellRendererText(), text=ACT_COL_CONN, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_CONN)
-        c = self.activities_list.insert_column_with_attributes(6, _('Channels'),
+        c = self.activities_list.insert_column_with_attributes(
+            6, _('Channels'),
             CellRendererText(), text=ACT_COL_CHANNELS, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
@@ -566,7 +571,8 @@ class PresenceServiceWatcher(VBox):
 
         self.pack_start(Label(_('Buddies:')), False, False)
         self.buddies_list = TreeView(self.buddies_list_store)
-        c = self.buddies_list.insert_column_with_attributes(0, _('Object path'),
+        c = self.buddies_list.insert_column_with_attributes(
+            0, _('Object path'),
             CellRendererText(), text=BUDDY_COL_PATH,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
@@ -641,17 +647,20 @@ class PresenceServiceWatcher(VBox):
     def _on_activity_appeared(self, path):
         if self.activities is None:
             return
-        self.log(_('INFO') + ': ' + _('PS emitted ActivityAppeared("%s")'), path)
+        self.log(
+            _('INFO') + ': ' + _('PS emitted ActivityAppeared("%s")'), path)
         self.activities[path] = ActivityWatcher(self, path)
 
     def _on_activity_disappeared(self, path):
         if self.activities is None:
             return
-        self.log(_('INFO') + ': ' + _('PS emitted ActivityDisappeared("%s")'), path)
+        self.log(
+            _('INFO') + ': ' + _('PS emitted ActivityDisappeared("%s")'), path)
         act = self.activities.get(path)
         if act is None:
-            self.log(_('WARNING') + ': '
-                     + _('Trying to remove activity "%s" which is already absent'), path)
+            self.log(
+                _('WARNING') + ': '
+                + _('Trying to remove activity "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             act.disappear()
@@ -660,9 +669,10 @@ class PresenceServiceWatcher(VBox):
         self.log(_('INFO') + ': ' + _('PS emitted ActivityInvitation("%s")'), path)
 
     def _on_private_invitation(self, bus_name, conn, channel):
-        self.log(_('INFO') + ': ' 
-                 + _('PS emitted PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
-                 {'bus':bus_name, 'conn':conn, 'channel':channel})
+        self.log(
+            _('INFO') + ': '
+            + _('PS emitted PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
+            {'bus':bus_name, 'conn':conn, 'channel':channel})
 
     def _on_get_buddies_success(self, paths):
         self.log(_('INFO') + ': ' + _('PS GetBuddies() returned %r'), paths)
@@ -697,7 +707,7 @@ class PresenceServiceWatcher(VBox):
         self.log(_('INFO') + ': ' + _('PS emitted BuddyDisappeared("%s")'), path)
         b = self.buddies.get(path)
         if b is None:
-            self.log(_('ERROR') + ': ' 
+            self.log(_('ERROR') + ': '
 		     + _('Trying to remove buddy "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -18,8 +18,8 @@ import logging
 from hashlib import sha1
 
 import dbus
-from gtk import VBox, Label, TreeView, Expander, ListStore, CellRendererText,\
-                ScrolledWindow, CellRendererToggle, TextView, VPaned
+from gtk import VBox, Label, TreeView, ListStore, CellRendererText,\
+                ScrolledWindow, CellRendererToggle, VPaned
 from gobject import timeout_add
 from gettext import gettext as _
 
@@ -121,7 +121,7 @@ class ActivityWatcher(object):
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
-            _('INFO') + ': ' 
+            _('INFO') + ': '
             + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
             {'path': self.object_path, 'buddy': buddy})
         try:
@@ -304,9 +304,9 @@ class BuddyWatcher(object):
             return
         self.ps_watcher.log(
             _('INFO') + ': '
-            + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
-            '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
-            'GetTelepathyHandles()') % 
+            + _('Buddy %(object_path)s emitted Telepathy HandleAdded( 
+            + \ '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in '
+            + \ 'GetTelepathyHandles()') %
             {'object_path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
@@ -339,8 +339,8 @@ class BuddyWatcher(object):
     def _on_get_handles_failure(self, e):
         self.ps_watcher.log(
             _('ERROR') + ': '
-            +_('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
-            {'path':self.object_path, 'e':e})
+            +_('< Buddy %(path)s >.GetTelepathyHandles(): %(e)s') %
+            {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_HANDLES,
                                                '!')
 
@@ -393,7 +393,7 @@ class BuddyWatcher(object):
             self.ps_watcher.log(
                 _('INFO') + ': '
                 + _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
-               {'path': self.object_path, 'props': props})
+                {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
             self.ps_watcher.log(_('INTERNAL ERROR: %s'), e)
@@ -518,28 +518,28 @@ class PresenceServiceWatcher(VBox):
         self.pack_start(Label(_('Activities:')), False, False)
 
         self.activities_list = TreeView(self.activities_list_store)
-        c = self.activities_list.insert_column_with_attributes(0,
-            _('Object path'), CellRendererText(), text=ACT_COL_PATH,
+        c = self.activities_list.insert_column_with_attributes(
+            0, _('Object path'), CellRendererText(), text=ACT_COL_PATH,
             weight=ACT_COL_WEIGHT, strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_PATH)
-        c = self.activities_list.insert_column_with_attributes(1, _('ID'),
-            CellRendererText(), text=ACT_COL_ID,
+        c = self.activities_list.insert_column_with_attributes(
+            1, _('ID'), CellRendererText(), text=ACT_COL_ID,
             weight=ACT_COL_WEIGHT, strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_ID)
-        c = self.activities_list.insert_column_with_attributes(2, _('Color'),
-            CellRendererText(), text=ACT_COL_COLOR,
+        c = self.activities_list.insert_column_with_attributes(
+            2, _('Color'), CellRendererText(), text=ACT_COL_COLOR,
             weight=ACT_COL_WEIGHT, strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_COLOR)
-        c = self.activities_list.insert_column_with_attributes(3, _('Type'),
-            CellRendererText(), text=ACT_COL_TYPE, weight=ACT_COL_WEIGHT,
+        c = self.activities_list.insert_column_with_attributes(
+            3, _('Type'), CellRendererText(), text=ACT_COL_TYPE, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_TYPE)
-        c = self.activities_list.insert_column_with_attributes(4, _('Name'),
-            CellRendererText(), text=ACT_COL_NAME, weight=ACT_COL_WEIGHT,
+        c = self.activities_list.insert_column_with_attributes(
+            4, _('Name'), CellRendererText(), text=ACT_COL_NAME, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_NAME)
@@ -554,7 +554,8 @@ class PresenceServiceWatcher(VBox):
             CellRendererText(), text=ACT_COL_CHANNELS, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
-        c = self.activities_list.insert_column_with_attributes(7, _('Buddies'),
+        c = self.activities_list.insert_column_with_attributes(
+            7, _('Buddies'),
             CellRendererText(), text=ACT_COL_BUDDIES, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
@@ -575,39 +576,47 @@ class PresenceServiceWatcher(VBox):
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_PATH)
-        c = self.buddies_list.insert_column_with_attributes(1, _('Pubkey'),
+        c = self.buddies_list.insert_column_with_attributes(
+            1, _('Pubkey'),
             CellRendererText(), text=BUDDY_COL_KEY_ID,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_KEY_ID)
-        c = self.buddies_list.insert_column_with_attributes(2, _('Nick'),
+        c = self.buddies_list.insert_column_with_attributes(
+            2, _('Nick'),
             CellRendererText(), text=BUDDY_COL_NICK,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_NICK)
-        c = self.buddies_list.insert_column_with_attributes(3, _('Owner'),
+        c = self.buddies_list.insert_column_with_attributes(
+            3, _('Owner'),
             CellRendererToggle(), active=BUDDY_COL_OWNER)
-        c = self.buddies_list.insert_column_with_attributes(4, _('Color'),
+        c = self.buddies_list.insert_column_with_attributes(
+            4, _('Color'),
             CellRendererText(), text=BUDDY_COL_COLOR,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_OWNER)
-        c = self.buddies_list.insert_column_with_attributes(5, _('IPv4'),
+        c = self.buddies_list.insert_column_with_attributes(
+            5, _('IPv4'),
             CellRendererText(), text=BUDDY_COL_IP4,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_IP4)
-        c = self.buddies_list.insert_column_with_attributes(6, _('CurAct'),
+        c = self.buddies_list.insert_column_with_attributes(
+            6, _('CurAct'),
             CellRendererText(), text=BUDDY_COL_CUR_ACT,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_CUR_ACT)
-        c = self.buddies_list.insert_column_with_attributes(7, _('Activities'),
+        c = self.buddies_list.insert_column_with_attributes(
+            7, _('Activities'),
             CellRendererText(), text=BUDDY_COL_ACTIVITIES,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(BUDDY_COL_ACTIVITIES)
-        c = self.buddies_list.insert_column_with_attributes(8, _('Handles'),
+        c = self.buddies_list.insert_column_with_attributes(
+            8, _('Handles'),
             CellRendererText(), text=BUDDY_COL_HANDLES,
             weight=BUDDY_COL_WEIGHT, strikethrough=BUDDY_COL_STRIKE)
         c.set_resizable(True)
@@ -671,7 +680,7 @@ class PresenceServiceWatcher(VBox):
         self.log(
             _('INFO') + ': '
             + _('PS emitted PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
-            {'bus':bus_name, 'conn':conn, 'channel':channel})
+            {'bus': bus_name, 'conn': conn, 'channel': channel})
 
     def _on_get_buddies_success(self, paths):
         self.log(_('INFO') + ': ' + _('PS GetBuddies() returned %r'), paths)
@@ -686,7 +695,8 @@ class PresenceServiceWatcher(VBox):
         path = b.object_path
         if path.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             path = '.../' + path[35:]
-        return self.buddies_list_store.append((path, 700, False,
+        return self.buddies_list_store.append(
+            (path, 700, False,
             b.nick, b.owner, b.color, b.ipv4, b.cur_act, b.keyid,
             '?', '?'))
 
@@ -707,8 +717,8 @@ class PresenceServiceWatcher(VBox):
             _('INFO') + ': ' + _('PS emitted BuddyDisappeared("%s")'), path)
         b = self.buddies.get(path)
         if b is None:
-             self.log(_('ERROR') + ': '
-             + _('Trying to remove buddy "%s" which is already absent'), path)
+            self.log(_('ERROR') + ': '
+            + _('Trying to remove buddy "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             b.disappear()

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -283,10 +283,10 @@ class BuddyWatcher(object):
     def _on_handle_added(self, service, conn, handle):
         if self.handles is None:
             return
-        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy %s emitted Telepathy HandleAdded(' + \
-                            '"%s", "%s", %u) or mentioned the handle in ' + \
-                            'GetTelepathyHandles()'),
-                            self.object_path, service, conn, handle)
+        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy {self.object_path} emitted Telepathy HandleAdded(' + \
+                            '"{service}", "{conn}", {handle}) or mentioned the handle in ' + \
+                            'GetTelepathyHandles()').format
+                            (self.object_path=self.object_path, service=service, conn=conn, handle=handle)
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
         self.handles.append('%u@%s' % (handle, conn))

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -108,8 +108,8 @@ class ActivityWatcher(object):
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Activity %(path)s emitted BuddyJoined("%(buddy)s")\
+            _('INFO') + ': ' +
+            _('Activity %(path)s emitted BuddyJoined("%(buddy)s")\
                 or mentioned the buddy in GetJoinedBuddies') %
             {'path': self.object_path, 'buddy': buddy})
         self.buddies.append(buddy)
@@ -122,8 +122,8 @@ class ActivityWatcher(object):
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
+            _('INFO') + ': ' +
+            _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
             {'path': self.object_path, 'buddy': buddy})
         try:
             self.buddies.remove(buddy)
@@ -139,8 +139,8 @@ class ActivityWatcher(object):
 
     def _on_get_buddies_failure(self, e):
         self.log(
-            _('ERROR') + ': '
-            + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
                                                   '!')
@@ -151,8 +151,8 @@ class ActivityWatcher(object):
         if channel.startswith(self.full_conn):
             channel = '...' + channel[len(self.full_conn):]
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Activity %(path)s emitted NewChannel("%(channel)s")\
+            _('INFO') + ': ' +
+            _('Activity %(path)s emitted NewChannel("%(channel)s")\
                 or mentioned the channel in GetChannels()') %
             {'path': self.object_path, 'channel': channel})
         self.channels.append(channel)
@@ -176,8 +176,8 @@ class ActivityWatcher(object):
 
     def _on_get_channels_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Activity %(path)s>.GetChannels(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Activity %(path)s>.GetChannels(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CONN,
                                                   '!')
@@ -190,8 +190,8 @@ class ActivityWatcher(object):
 
     def _on_get_id_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Activity %(path)s>.GetId(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Activity %(path)s>.GetId(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_ID,
                                                   '!')
@@ -203,8 +203,8 @@ class ActivityWatcher(object):
 
     def _on_get_color_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Activity %(path)s>.GetColor(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Activity %(path)s>.GetColor(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_COLOR,
                                                   '!')
@@ -216,8 +216,8 @@ class ActivityWatcher(object):
 
     def _on_get_type_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Activity %(path)s>.GetType(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Activity %(path)s>.GetType(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_TYPE,
                                                   '!')
@@ -229,8 +229,8 @@ class ActivityWatcher(object):
 
     def _on_get_name_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Activity %(path)s>.GetName(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Activity %(path)s>.GetName(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_NAME,
                                                   '!')
@@ -305,8 +305,8 @@ class BuddyWatcher(object):
         if self.handles is None:
             return
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Buddy %(object_path)s emitted Telepathy HandleAdded('
+            _('INFO') + ': ' +
+            _('Buddy %(object_path)s emitted Telepathy HandleAdded('
                 '"%(service)s", "%(conn)s", %(handle)u)\
                 or mentioned the handle in '
                 'GetTelepathyHandles()') %
@@ -325,8 +325,8 @@ class BuddyWatcher(object):
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Buddy %(path)s emitted \
+            _('INFO') + ': ' +
+            _('Buddy %(path)s emitted \
                 HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') %
             {'path': self.object_path, 'service': service,
              'conn': conn, 'handle': handle})
@@ -344,8 +344,8 @@ class BuddyWatcher(object):
 
     def _on_get_handles_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_HANDLES,
                                                '!')
@@ -356,8 +356,8 @@ class BuddyWatcher(object):
         if act.startswith('/org/laptop/Sugar/Presence/Activities/'):
             act = '.../' + act[38:]
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Buddy %(path)s emitted ActivityJoined("%(act)s")\
+            _('INFO') + ': ' +
+            _('Buddy %(path)s emitted ActivityJoined("%(act)s")\
                 or mentioned it in GetJoinedActivities()') %
             {'path': self.object_path, 'act': act})
         self.activities.append(act)
@@ -371,8 +371,8 @@ class BuddyWatcher(object):
         if act.startswith('/org/laptop/Sugar/Presence/Activities/'):
             act = '.../' + act[38:]
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Buddy %(path)s emitted ActivityLeft("%(act)s")') %
+            _('INFO') + ': ' +
+            _('Buddy %(path)s emitted ActivityLeft("%(act)s")') %
             {'path': self.object_path, 'act': act})
         try:
             self.activities.remove(act)
@@ -388,8 +388,8 @@ class BuddyWatcher(object):
 
     def _on_get_acts_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Buddy %(path)s>.GetJoinedActivities(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Buddy %(path)s>.GetJoinedActivities(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_ACTIVITIES,
                                                '!')
@@ -398,8 +398,8 @@ class BuddyWatcher(object):
         try:
             logger.debug('PropertyChanged(%s, %s)', self, props)
             self.ps_watcher.log(
-                _('INFO') + ': '
-                + _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
+                _('INFO') + ': ' +
+                _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
                 {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
@@ -409,8 +409,8 @@ class BuddyWatcher(object):
         try:
             logger.debug('GetProperties(%s, %s)', self, props)
             self.ps_watcher.log(
-                _('INFO') + ': '
-                + _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
+                _('INFO') + ': ' +
+                _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
                 {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
@@ -453,8 +453,8 @@ class BuddyWatcher(object):
 
     def _on_get_props_failure(self, e):
         self.ps_watcher.log(
-            _('ERROR') + ': '
-            + _('<Buddy %(path)s>.GetProperties(): %(e)s') %
+            _('ERROR') + ': ' +
+            _('<Buddy %(path)s>.GetProperties(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_NICK, '!')
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_OWNER,
@@ -677,8 +677,8 @@ class PresenceServiceWatcher(VBox):
         act = self.activities.get(path)
         if act is None:
             self.log(
-                _('WARNING') + ': '
-                + _('Trying to remove activity "%s"\
+                _('WARNING') + ': ' +
+                _('Trying to remove activity "%s"\
                     which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
@@ -690,8 +690,8 @@ class PresenceServiceWatcher(VBox):
 
     def _on_private_invitation(self, bus_name, conn, channel):
         self.log(
-            _('INFO') + ': '
-            + _('PS emitted\
+            _('INFO') + ': ' +
+            _('PS emitted\
                 PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
             {'bus': bus_name, 'conn': conn, 'channel': channel})
 
@@ -731,8 +731,8 @@ class PresenceServiceWatcher(VBox):
         b = self.buddies.get(path)
         if b is None:
             self.log(
-                _('ERROR') + ': '
-                + _('Trying to remove buddy "%s"\
+                _('ERROR') + ': ' +
+                _('Trying to remove buddy "%s"\
                     which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -303,10 +303,9 @@ class BuddyWatcher(object):
         if self.handles is None:
             return
         self.ps_watcher.log(
-            _('INFO') + ': '
-            + _('Buddy %(object_path)s emitted Telepathy HandleAdded( 
-            + \ '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in '
-            + \ 'GetTelepathyHandles()') %
+            _('INFO') + ': ' + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
+            '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
+            'GetTelepathyHandles()') %
             {'object_path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
@@ -339,7 +338,7 @@ class BuddyWatcher(object):
     def _on_get_handles_failure(self, e):
         self.ps_watcher.log(
             _('ERROR') + ': '
-            +_('< Buddy %(path)s >.GetTelepathyHandles(): %(e)s') %
+            +_('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_HANDLES,
                                                '!')
@@ -644,8 +643,9 @@ class PresenceServiceWatcher(VBox):
         path = act.object_path
         if path.startswith('/org/laptop/Sugar/Presence/Activities/'):
             path = '.../' + path[38:]
-        return self.activities_list_store.append((path, 700, False,
-            act.id, act.color, act.type, act.name, act.conn, '?', '?'))
+        return self.activities_list_store.append(
+            (path, 700, False,
+             act.id, act.color, act.type, act.name, act.conn, '?', '?'))
 
     def remove_activity(self, act):
         self.activities.pop(act.object_path, None)
@@ -697,8 +697,8 @@ class PresenceServiceWatcher(VBox):
             path = '.../' + path[35:]
         return self.buddies_list_store.append(
             (path, 700, False,
-            b.nick, b.owner, b.color, b.ipv4, b.cur_act, b.keyid,
-            '?', '?'))
+             b.nick, b.owner, b.color, b.ipv4, b.cur_act, b.keyid,
+             '?', '?'))
 
     def remove_buddy(self, b):
         self.buddies.pop(b.object_path, None)
@@ -717,8 +717,9 @@ class PresenceServiceWatcher(VBox):
             _('INFO') + ': ' + _('PS emitted BuddyDisappeared("%s")'), path)
         b = self.buddies.get(path)
         if b is None:
-            self.log(_('ERROR') + ': '
-            + _('Trying to remove buddy "%s" which is already absent'), path)
+            self.log(
+                _('ERROR') + ': '
+                + _('Trying to remove buddy "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             b.disappear()

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -109,7 +109,8 @@ class ActivityWatcher(object):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
             _('INFO') + ': '
-            + _('Activity %(path)s emitted BuddyJoined("%(buddy)s") or mentioned the buddy in GetJoinedBuddies') %
+            + _('Activity %(path)s emitted BuddyJoined("%(buddy)s")\
+                or mentioned the buddy in GetJoinedBuddies') %
             {'path': self.object_path, 'buddy': buddy})
         self.buddies.append(buddy)
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
@@ -151,7 +152,8 @@ class ActivityWatcher(object):
             channel = '...' + channel[len(self.full_conn):]
         self.ps_watcher.log(
             _('INFO') + ': '
-            + _('Activity %(path)s emitted NewChannel("%(channel)s") or mentioned the channel in GetChannels()') %
+            + _('Activity %(path)s emitted NewChannel("%(channel)s")\
+                or mentioned the channel in GetChannels()') %
             {'path': self.object_path, 'channel': channel})
         self.channels.append(channel)
         # FIXME: listen for Telepathy Closed signal!
@@ -303,10 +305,13 @@ class BuddyWatcher(object):
         if self.handles is None:
             return
         self.ps_watcher.log(
-            _('INFO') + ': ' + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
-            '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
-            'GetTelepathyHandles()') %
-            {'object_path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
+            _('INFO') + ': '
+            + _('Buddy %(object_path)s emitted Telepathy HandleAdded('
+                '"%(service)s", "%(conn)s", %(handle)u)\
+                or mentioned the handle in '\
+                'GetTelepathyHandles()') %
+            {'object_path': self.object_path, 'service': service,
+             'conn': conn, 'handle': handle})
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
         self.handles.append('%u@%s' % (handle, conn))
@@ -321,8 +326,10 @@ class BuddyWatcher(object):
             conn = '.../' + conn[38:]
         self.ps_watcher.log(
             _('INFO') + ': '
-            + _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') %
-            {'path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
+            + _('Buddy %(path)s emitted \
+                HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') %
+            {'path': self.object_path, 'service': service,
+             'conn': conn, 'handle': handle})
         try:
             self.handles.remove('%u@%s' % (handle, conn))
         except ValueError:
@@ -338,7 +345,7 @@ class BuddyWatcher(object):
     def _on_get_handles_failure(self, e):
         self.ps_watcher.log(
             _('ERROR') + ': '
-            +_('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
+            + _('<Buddy %(path)s>.GetTelepathyHandles(): %(e)s') %
             {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_HANDLES,
                                                '!')
@@ -350,7 +357,8 @@ class BuddyWatcher(object):
             act = '.../' + act[38:]
         self.ps_watcher.log(
             _('INFO') + ': '
-            + _('Buddy %(path)s emitted ActivityJoined("%(act)s") or mentioned it in GetJoinedActivities()') %
+            + _('Buddy %(path)s emitted ActivityJoined("%(act)s")\
+                or mentioned it in GetJoinedActivities()') %
             {'path': self.object_path, 'act': act})
         self.activities.append(act)
         self.ps_watcher.buddies_list_store.set(self.iter,
@@ -436,7 +444,8 @@ class BuddyWatcher(object):
                 self.keyid = '%d bytes, sha1 %s' % (len(key),
                                                     sha1(key).hexdigest())
             else:
-                # could be '' (present, empty value) or None (absent). Either way:
+                # could be '' (present, empty value) or None (absent). 
+                # Either way:
                 self.keyid = '?'
             self.ps_watcher.buddies_list_store.set(
                 self.iter, BUDDY_COL_KEY_ID, self.keyid)
@@ -533,12 +542,14 @@ class PresenceServiceWatcher(VBox):
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_COLOR)
         c = self.activities_list.insert_column_with_attributes(
-            3, _('Type'), CellRendererText(), text=ACT_COL_TYPE, weight=ACT_COL_WEIGHT,
+            3, _('Type'),
+            CellRendererText(), text=ACT_COL_TYPE, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_TYPE)
         c = self.activities_list.insert_column_with_attributes(
-            4, _('Name'), CellRendererText(), text=ACT_COL_NAME, weight=ACT_COL_WEIGHT,
+            4, _('Name'),
+            CellRendererText(), text=ACT_COL_NAME, weight=ACT_COL_WEIGHT,
             strikethrough=ACT_COL_STRIKE)
         c.set_resizable(True)
         c.set_sort_column_id(ACT_COL_NAME)
@@ -667,7 +678,8 @@ class PresenceServiceWatcher(VBox):
         if act is None:
             self.log(
                 _('WARNING') + ': '
-                + _('Trying to remove activity "%s" which is already absent'), path)
+                + _('Trying to remove activity "%s"\
+                    which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             act.disappear()
@@ -679,7 +691,8 @@ class PresenceServiceWatcher(VBox):
     def _on_private_invitation(self, bus_name, conn, channel):
         self.log(
             _('INFO') + ': '
-            + _('PS emitted PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
+            + _('PS emitted\
+                PrivateInvitation("%(bus)s", "%(conn)s", "%(channel)s")') %
             {'bus': bus_name, 'conn': conn, 'channel': channel})
 
     def _on_get_buddies_success(self, paths):
@@ -719,7 +732,8 @@ class PresenceServiceWatcher(VBox):
         if b is None:
             self.log(
                 _('ERROR') + ': '
-                + _('Trying to remove buddy "%s" which is already absent'), path)
+                + _('Trying to remove buddy "%s"\
+                    which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             b.disappear()

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -121,7 +121,8 @@ class ActivityWatcher(object):
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
         self.ps_watcher.log(
-            _('INFO') + ': ' + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
+            _('INFO') + ': ' 
+            + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
             {'path': self.object_path, 'buddy': buddy})
         try:
             self.buddies.remove(buddy)
@@ -305,11 +306,8 @@ class BuddyWatcher(object):
             _('INFO') + ': '
             + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
             '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
-            'GetTelepathyHandles()').format
-            % {'object_path': self.object_path,
-               'service': service,
-               'conn': conn,
-               'handle': handle }
+            'GetTelepathyHandles()') % 
+            {'object_path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
         self.handles.append('%u@%s' % (handle, conn))
@@ -441,8 +439,8 @@ class BuddyWatcher(object):
             else:
                 # could be '' (present, empty value) or None (absent). Either way:
                 self.keyid = '?'
-            self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_KEY_ID,
-                                                   self.keyid)
+            self.ps_watcher.buddies_list_store.set(
+                self.iter, BUDDY_COL_KEY_ID, self.keyid)
         logger.debug('End _props_changed')
 
     def _on_get_props_failure(self, e):
@@ -666,7 +664,8 @@ class PresenceServiceWatcher(VBox):
             act.disappear()
 
     def _on_activity_invitation(self, path):
-        self.log(_('INFO') + ': ' + _('PS emitted ActivityInvitation("%s")'), path)
+        self.log(
+            _('INFO') + ': ' + _('PS emitted ActivityInvitation("%s")'), path)
 
     def _on_private_invitation(self, bus_name, conn, channel):
         self.log(
@@ -704,11 +703,12 @@ class PresenceServiceWatcher(VBox):
     def _on_buddy_disappeared(self, path):
         if self.buddies is None:
             return
-        self.log(_('INFO') + ': ' + _('PS emitted BuddyDisappeared("%s")'), path)
+        self.log(
+            _('INFO') + ': ' + _('PS emitted BuddyDisappeared("%s")'), path)
         b = self.buddies.get(path)
         if b is None:
-            self.log(_('ERROR') + ': '
-		     + _('Trying to remove buddy "%s" which is already absent'), path)
+             self.log(_('ERROR') + ': '
+             + _('Trying to remove buddy "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             b.disappear()

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -283,10 +283,13 @@ class BuddyWatcher(object):
     def _on_handle_added(self, service, conn, handle):
         if self.handles is None:
             return
-        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy {self.object_path} emitted Telepathy HandleAdded(' + \
-                            '"{service}", "{conn}", {handle}) or mentioned the handle in ' + \
+        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
+                            '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
                             'GetTelepathyHandles()').format
-                            (self.object_path=self.object_path, service=service, conn=conn, handle=handle)
+                            % {'object_path': self.object_path,
+			       'service': service,
+			       'conn': conn,
+			       'handle': handle }
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
         self.handles.append('%u@%s' % (handle, conn))

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -24,8 +24,8 @@ from gobject import timeout_add
 from gettext import gettext as _
 
 logger = logging.getLogger('ps_watcher')
-#logging.basicConfig(filename='/tmp/ps_watcher.log')
-#logging.getLogger().setLevel(1)
+# logging.basicConfig(filename='/tmp/ps_watcher.log')
+# logging.getLogger().setLevel(1)
 
 
 PS_NAME = 'org.laptop.Sugar.Presence'
@@ -107,8 +107,10 @@ class ActivityWatcher(object):
             return
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
-        self.ps_watcher.log(_('INFO') + ': ' + _('Activity %(path)s emitted BuddyJoined("%(buddy)s") or mentioned the buddy in GetJoinedBuddies') %
-                            {'path':self.object_path, 'buddy':buddy})
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Activity %(path)s emitted BuddyJoined("%(buddy)s") 
+				or mentioned the buddy in GetJoinedBuddies') %
+                            {'path': self.object_path, 'buddy': buddy})
         self.buddies.append(buddy)
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
                                                   ' '.join(self.buddies))
@@ -118,8 +120,9 @@ class ActivityWatcher(object):
             return
         if buddy.startswith('/org/laptop/Sugar/Presence/Buddies/'):
             buddy = '.../' + buddy[35:]
-        self.ps_watcher.log(_('INFO') + ': ' + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
-                            {'path':self.object_path, 'buddy':buddy})
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Activity %(path)s emitted BuddyLeft("%(buddy)s")') %
+                            {'path': self.object_path, 'buddy': buddy})
         try:
             self.buddies.remove(buddy)
         except ValueError:
@@ -133,8 +136,9 @@ class ActivityWatcher(object):
             self._on_buddy_joined(buddy)
 
     def _on_get_buddies_failure(self, e):
-        self.log(_('ERROR') + ': ' + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') % 
-                 {'path':self.object_path, 'e':e})
+        self.log(_('ERROR') + ': ' 
+		 + _('<Activity %(path)s>.GetJoinedBuddies(): %(e)s') % 
+                 {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_BUDDIES,
                                                   '!')
 
@@ -143,8 +147,10 @@ class ActivityWatcher(object):
             return
         if channel.startswith(self.full_conn):
             channel = '...' + channel[len(self.full_conn):]
-        self.ps_watcher.log(_('INFO') + ': ' + _('Activity %(path)s emitted NewChannel("%(channel)s") or mentioned the channel in GetChannels()') %
-                            {'path':self.object_path, 'channel':channel})
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Activity %(path)s emitted NewChannel("%(channel)s")
+				or mentioned the channel in GetChannels()') %
+                            {'path': self.object_path, 'channel': channel})
         self.channels.append(channel)
         # FIXME: listen for Telepathy Closed signal!
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CHANNELS,
@@ -165,8 +171,9 @@ class ActivityWatcher(object):
                                                   ' '.join(self.channels))
 
     def _on_get_channels_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Activity %(path)s>.GetChannels(): %(e)s') %
-                            {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Activity %(path)s>.GetChannels(): %(e)s') %
+                            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CONN,
                                                   '!')
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_CHANNELS,
@@ -177,8 +184,9 @@ class ActivityWatcher(object):
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_ID, ident)
 
     def _on_get_id_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Activity %(path)s>.GetId(): %(e)s') %
-                            {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Activity %(path)s>.GetId(): %(e)s') %
+                            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_ID,
                                                   '!')
 
@@ -188,8 +196,9 @@ class ActivityWatcher(object):
                                                   color)
 
     def _on_get_color_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Activity %(path)s>.GetColor(): %(e)s') %
-                            {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Activity %(path)s>.GetColor(): %(e)s') %
+                            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_COLOR,
                                                   '!')
 
@@ -199,8 +208,9 @@ class ActivityWatcher(object):
                                                   type_)
 
     def _on_get_type_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Activity %(path)s>.GetType(): %(e)s') %
-                            {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Activity %(path)s>.GetType(): %(e)s') %
+                            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_TYPE,
                                                   '!')
 
@@ -210,8 +220,9 @@ class ActivityWatcher(object):
                                                   name)
 
     def _on_get_name_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Activity %(path)s>.GetName(): %(e)s') %
-                            {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Activity %(path)s>.GetName(): %(e)s') %
+                            {'path': self.object_path, 'e': e})
         self.ps_watcher.activities_list_store.set(self.iter, ACT_COL_NAME,
                                                   '!')
 
@@ -283,7 +294,8 @@ class BuddyWatcher(object):
     def _on_handle_added(self, service, conn, handle):
         if self.handles is None:
             return
-        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Buddy %(object_path)s emitted Telepathy HandleAdded(' + \
                             '"%(service)s", "%(conn)s", %(handle)u) or mentioned the handle in ' + \
                             'GetTelepathyHandles()').format
                             % {'object_path': self.object_path,
@@ -302,8 +314,9 @@ class BuddyWatcher(object):
             return
         if conn.startswith('/org/freedesktop/Telepathy/Connection/'):
             conn = '.../' + conn[38:]
-        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') % 
-			    {'path':self.object_path, 'service':service, 'conn':conn, 'handle':handle})
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Buddy %(path)s emitted HandleRemoved("%(service)s", "%(conn)s", %(handle)u)') % 
+			    {'path': self.object_path, 'service': service, 'conn': conn, 'handle': handle})
         try:
             self.handles.remove('%u@%s' % (handle, conn))
         except ValueError:
@@ -327,8 +340,10 @@ class BuddyWatcher(object):
             return
         if act.startswith('/org/laptop/Sugar/Presence/Activities/'):
             act = '.../' + act[38:]
-        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy %(path)s emitted ActivityJoined("%(act)s") or mentioned it in GetJoinedActivities()') %
-                            {'path':self.object_path, 'act':act})
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Buddy %(path)s emitted ActivityJoined("%(act)s") 
+				or mentioned it in GetJoinedActivities()') %
+                            {'path': self.object_path, 'act': act})
         self.activities.append(act)
         self.ps_watcher.buddies_list_store.set(self.iter,
                                                BUDDY_COL_ACTIVITIES,
@@ -339,8 +354,9 @@ class BuddyWatcher(object):
             return
         if act.startswith('/org/laptop/Sugar/Presence/Activities/'):
             act = '.../' + act[38:]
-        self.ps_watcher.log(_('INFO') + ': ' + _('Buddy %(path)s emitted ActivityLeft("%(act)s")') %
-                            {'path':self.object_path, 'act':act})
+        self.ps_watcher.log(_('INFO') + ': ' 
+			    + _('Buddy %(path)s emitted ActivityLeft("%(act)s")') %
+                            {'path': self.object_path, 'act': act})
         try:
             self.activities.remove(act)
         except ValueError:
@@ -354,16 +370,18 @@ class BuddyWatcher(object):
             self._on_joined(act)
 
     def _on_get_acts_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Buddy %(path)s>.GetJoinedActivities(): %(e)s') %
-                 {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Buddy %(path)s>.GetJoinedActivities(): %(e)s') %
+                 {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_ACTIVITIES,
                                                '!')
 
     def _on_props_changed(self, props):
         try:
             logger.debug('PropertyChanged(%s, %s)', self, props)
-            self.ps_watcher.log(_('INFO') + ': ' + _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
-                                {'path':self.object_path, 'props':props})
+            self.ps_watcher.log(_('INFO') + ': ' 
+				+ _('<Buddy %(path)s> emitted PropertyChanged(%(props)r)') %
+                                {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
             self.ps_watcher.log(_('INTERNAL ERROR: %s'), e)
@@ -371,8 +389,9 @@ class BuddyWatcher(object):
     def _on_get_props_success(self, props):
         try:
             logger.debug('GetProperties(%s, %s)', self, props)
-            self.ps_watcher.log(_('INFO') + ': ' + _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
-                     {'path':self.object_path, 'props':props})
+            self.ps_watcher.log(_('INFO') + ': ' 
+				+ _('<Buddy %(path)s>.GetProperties() -> %(props)r') %
+                     {'path': self.object_path, 'props': props})
             self._props_changed(props)
         except Exception, e:
             self.ps_watcher.log(_('INTERNAL ERROR: %s'), e)
@@ -412,8 +431,9 @@ class BuddyWatcher(object):
         logger.debug('End _props_changed')
 
     def _on_get_props_failure(self, e):
-        self.ps_watcher.log(_('ERROR') + ': ' + _('<Buddy %(path)s>.GetProperties(): %(e)s') %
-                            {'path':self.object_path, 'e':e})
+        self.ps_watcher.log(_('ERROR') + ': ' 
+			    + _('<Buddy %(path)s>.GetProperties(): %(e)s') %
+                            {'path': self.object_path, 'e': e})
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_NICK, '!')
         self.ps_watcher.buddies_list_store.set(self.iter, BUDDY_COL_OWNER,
                                                False)
@@ -662,7 +682,8 @@ class PresenceServiceWatcher(VBox):
         self.log(_('INFO') + ': ' + _('PS emitted BuddyDisappeared("%s")'), path)
         b = self.buddies.get(path)
         if b is None:
-            self.log(_('ERROR') + ': ' + _('Trying to remove buddy "%s" which is already absent'), path)
+            self.log(_('ERROR') + ': ' 
+		     + _('Trying to remove buddy "%s" which is already absent'), path)
         else:
             # we don't remove the activity straight away, just cross it out
             b.disappear()

--- a/ps_watcher.py
+++ b/ps_watcher.py
@@ -308,7 +308,7 @@ class BuddyWatcher(object):
             _('INFO') + ': '
             + _('Buddy %(object_path)s emitted Telepathy HandleAdded('
                 '"%(service)s", "%(conn)s", %(handle)u)\
-                or mentioned the handle in '\
+                or mentioned the handle in '
                 'GetTelepathyHandles()') %
             {'object_path': self.object_path, 'service': service,
              'conn': conn, 'handle': handle})
@@ -444,7 +444,7 @@ class BuddyWatcher(object):
                 self.keyid = '%d bytes, sha1 %s' % (len(key),
                                                     sha1(key).hexdigest())
             else:
-                # could be '' (present, empty value) or None (absent). 
+                # could be '' (present, empty value) or None (absent).
                 # Either way:
                 self.keyid = '?'
             self.ps_watcher.buddies_list_store.set(


### PR DESCRIPTION
This pull request solves #3. I added the named arguments to the format string in `ps_watcher.py`. 

- I then tested the `genpot` command and the command executed successfully. 
- I also tested other commands such as `dist_source` and `dist_xo` and they work fine. 
- I also ran the `install` command - there were no errors but the activity still does not work from #1 